### PR TITLE
#2 - Made DataBuilder().none() call optional

### DIFF
--- a/docu/docs/about/release-notes.md
+++ b/docu/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 2.1.0 (2023-XX-YY)
+
+- [#2](https://github.com/jnk-cons/easy-rscp/issues/2)) DataBuilder().none() is optional, now
+  - It To create a data block of data type `NONE`, the function `none()` must no longer be called explicitly. This behavior is now default.
+  - The examples in the documentation have been adjusted.
+
 ## Version 2.0.0 (2023-09-22)
 
 - Initial Public release

--- a/docu/docs/lowlevel/connection.md
+++ b/docu/docs/lowlevel/connection.md
@@ -36,11 +36,11 @@ To be able to read the answer we use the `StringFrameConverter` to output the an
         val answer = connectionPool.executeAndRelease {
             it.send(FrameBuilder()
                         .addData(
-                            DataBuilder().tag(EMSTag.REQ_POWER_PV).none().build(),
-                            DataBuilder().tag(EMSTag.REQ_POWER_BAT).none().build(),
-                            DataBuilder().tag(EMSTag.REQ_POWER_GRID).none().build(),
-                            DataBuilder().tag(EMSTag.REQ_POWER_HOME).none().build(),
-                            DataBuilder().tag(EMSTag.REQ_BAT_SOC).none().build(),
+                            DataBuilder().tag(EMSTag.REQ_POWER_PV).build(),
+                            DataBuilder().tag(EMSTag.REQ_POWER_BAT).build(),
+                            DataBuilder().tag(EMSTag.REQ_POWER_GRID).build(),
+                            DataBuilder().tag(EMSTag.REQ_POWER_HOME).build(),
+                            DataBuilder().tag(EMSTag.REQ_BAT_SOC).build(),
                         ).build()
             )
         }
@@ -75,11 +75,11 @@ To be able to read the answer we use the `StringFrameConverter` to output the an
             Frame answer = connectionPool.executeAndRelease(connection -> {
                 Frame requestFrame = new FrameBuilder()
                     .addData(
-                        new DataBuilder().tag(EMSTag.REQ_POWER_PV).none().build(),
-                        new DataBuilder().tag(EMSTag.REQ_POWER_BAT).none().build(),
-                        new DataBuilder().tag(EMSTag.REQ_POWER_GRID).none().build(),
-                        new DataBuilder().tag(EMSTag.REQ_POWER_HOME).none().build(),
-                        new DataBuilder().tag(EMSTag.REQ_BAT_SOC).none().build()
+                        new DataBuilder().tag(EMSTag.REQ_POWER_PV).build(),
+                        new DataBuilder().tag(EMSTag.REQ_POWER_BAT).build(),
+                        new DataBuilder().tag(EMSTag.REQ_POWER_GRID).build(),
+                        new DataBuilder().tag(EMSTag.REQ_POWER_HOME).build(),
+                        new DataBuilder().tag(EMSTag.REQ_BAT_SOC).build()
                         ).build();
                 return connection.send(requestFrame);
             });

--- a/docu/docs/lowlevel/frame.md
+++ b/docu/docs/lowlevel/frame.md
@@ -31,11 +31,11 @@ Here is an example of how to put together a query frame that asks for some live 
     fun main() {
         val requestFrame = FrameBuilder()
                 .addData(
-                    DataBuilder().tag(EMSTag.REQ_POWER_PV).none().build(),
-                    DataBuilder().tag(EMSTag.REQ_POWER_BAT).none().build(),
-                    DataBuilder().tag(EMSTag.REQ_POWER_GRID).none().build(),
-                    DataBuilder().tag(EMSTag.REQ_POWER_HOME).none().build(),
-                    DataBuilder().tag(EMSTag.REQ_BAT_SOC).none().build(),
+                    DataBuilder().tag(EMSTag.REQ_POWER_PV).build(),
+                    DataBuilder().tag(EMSTag.REQ_POWER_BAT).build(),
+                    DataBuilder().tag(EMSTag.REQ_POWER_GRID).build(),
+                    DataBuilder().tag(EMSTag.REQ_POWER_HOME).build(),
+                    DataBuilder().tag(EMSTag.REQ_BAT_SOC).build(),
                 ).build()
     
         println(StringFrameConverter().invoke(requestFrame))
@@ -53,11 +53,11 @@ Here is an example of how to put together a query frame that asks for some live 
         public static void main(String[] args) {
             Frame requestFrame =  new FrameBuilder()
                 .addData(
-                    new DataBuilder().tag(EMSTag.REQ_POWER_PV).none().build(),
-                    new DataBuilder().tag(EMSTag.REQ_POWER_BAT).none().build(),
-                    new DataBuilder().tag(EMSTag.REQ_POWER_GRID).none().build(),
-                    new DataBuilder().tag(EMSTag.REQ_POWER_HOME).none().build(),
-                    new DataBuilder().tag(EMSTag.REQ_BAT_SOC).none().build()
+                    new DataBuilder().tag(EMSTag.REQ_POWER_PV).build(),
+                    new DataBuilder().tag(EMSTag.REQ_POWER_BAT).build(),
+                    new DataBuilder().tag(EMSTag.REQ_POWER_GRID).build(),
+                    new DataBuilder().tag(EMSTag.REQ_POWER_HOME).build(),
+                    new DataBuilder().tag(EMSTag.REQ_BAT_SOC).build()
                 ).build();
     
             System.out.println(new StringFrameConverter().invoke(requestFrame));

--- a/docu/docs/service/extension-points.md
+++ b/docu/docs/service/extension-points.md
@@ -150,10 +150,10 @@ Here is an example of how to set your own creator on the `InfoService`:
         override fun invoke(param: Nothing?) =
             FrameBuilder()
                 .addData(
-                    DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).none().build(),
-                    DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).none().build(),
-                    DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).none().build(),
-                    DataBuilder().tag(InfoTag.REQ_SW_RELEASE).none().build()
+                    DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).build(),
+                    DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).build(),
+                    DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).build(),
+                    DataBuilder().tag(InfoTag.REQ_SW_RELEASE).build()
                 )
                 .build()
     }
@@ -188,10 +188,10 @@ Here is an example of how to set your own creator on the `InfoService`:
         public Frame invoke(Void unused) {
             return new FrameBuilder()
                 .addData(
-                    new DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).none().build(),
-                    new DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).none().build(),
-                    new DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).none().build(),
-                    new DataBuilder().tag(InfoTag.REQ_SW_RELEASE).none().build()
+                    new DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).build(),
+                    new DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).build(),
+                    new DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).build(),
+                    new DataBuilder().tag(InfoTag.REQ_SW_RELEASE).build()
                 )
                 .build();
         }

--- a/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestChargingConfigurationCreator.kt
+++ b/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestChargingConfigurationCreator.kt
@@ -15,8 +15,8 @@ class RequestChargingConfigurationCreator: FrameCreator<Nothing?> {
     override fun invoke(param: Nothing?): Frame =
         FrameBuilder()
             .addData(
-                DataBuilder().tag(EMSTag.REQ_GET_POWER_SETTINGS).none().build(),
-                DataBuilder().tag(EMSTag.REQ_GET_SYS_SPECS).none().build()
+                DataBuilder().tag(EMSTag.REQ_GET_POWER_SETTINGS).build(),
+                DataBuilder().tag(EMSTag.REQ_GET_SYS_SPECS).build()
             )
             .build()
 }

--- a/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestLiveDataCreator.kt
+++ b/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestLiveDataCreator.kt
@@ -16,11 +16,11 @@ class RequestLiveDataCreator: FrameCreator<Nothing?> {
     override fun invoke(param: Nothing?): Frame =
         FrameBuilder()
             .addData(
-                DataBuilder().tag(EMSTag.REQ_POWER_PV).none().build(),
-                DataBuilder().tag(EMSTag.REQ_POWER_BAT).none().build(),
-                DataBuilder().tag(EMSTag.REQ_POWER_GRID).none().build(),
-                DataBuilder().tag(EMSTag.REQ_POWER_HOME).none().build(),
-                DataBuilder().tag(EMSTag.REQ_BAT_SOC).none().build(),
+                DataBuilder().tag(EMSTag.REQ_POWER_PV).build(),
+                DataBuilder().tag(EMSTag.REQ_POWER_BAT).build(),
+                DataBuilder().tag(EMSTag.REQ_POWER_GRID).build(),
+                DataBuilder().tag(EMSTag.REQ_POWER_HOME).build(),
+                DataBuilder().tag(EMSTag.REQ_BAT_SOC).build(),
             )
             .build()
 }

--- a/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestSystemInfosCreator.kt
+++ b/service/src/main/kotlin/de/jnkconsulting/e3dc/easyrscp/service/creator/RequestSystemInfosCreator.kt
@@ -16,10 +16,10 @@ class RequestSystemInfosCreator: FrameCreator<Nothing?> {
     override fun invoke(param: Nothing?): Frame =
         FrameBuilder()
             .addData(
-                DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).none().build(),
-                DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).none().build(),
-                DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).none().build(),
-                DataBuilder().tag(InfoTag.REQ_SW_RELEASE).none().build()
+                DataBuilder().tag(InfoTag.REQ_MAC_ADDRESS).build(),
+                DataBuilder().tag(InfoTag.REQ_PRODUCTION_DATE).build(),
+                DataBuilder().tag(InfoTag.REQ_SERIAL_NUMBER).build(),
+                DataBuilder().tag(InfoTag.REQ_SW_RELEASE).build()
             )
             .build()
 }


### PR DESCRIPTION
- [#2](https://github.com/jnk-cons/easy-rscp/issues/2)) DataBuilder().none() is optional, now
  - It To create a data block of data type `NONE`, the function `none()` must no longer be called explicitly. This behavior is now default.
  - The examples in the documentation have been adjusted.